### PR TITLE
docs: add comprehensive zsh role documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The repository follows standard Ansible structure:
 
 - **Core files:** ansible.cfg, playbook.yml, .inventory, .requirements.yml
 - **Execution scripts:** bootstrap.sh (setup), run.sh (execution)
-- **Roles:** packages/, ssh/, git/, chezmoi/ (each with tasks/, templates/, defaults/, meta/)
+- **Roles:** packages/, ssh/, git/, chezmoi/, zsh/, cloudflared/ (each with tasks/, templates/, defaults/, meta/)
 - **Variables:** vars/ directory with role-specific configuration files
 - **Documentation:** docs/ with primitives reference and historical repos
 - **Collections:** Installed Ansible Galaxy collections (community.general, kewlfft.aur, ansible.posix)
@@ -24,7 +24,7 @@ The repository follows standard Ansible structure:
 - **Become method:** `become: true` on individual tasks (not playbook level)
 - **Sudo password:** Set via `$ANSIBLE_BECOME_PASSWORD_FILE` exported by `skogcli` through `.envrc`
 - **Python interpreter:** Hardcoded venv path in `ansible.cfg`: `/home/skogix/.ansible/.venv/bin/python`
-- **Variable organization:** Role-specific vars files (packages.yml, ssh.yml, git.yml, chezmoi.yml, user.yml)
+- **Variable organization:** Role-specific vars files (packages.yml, ssh.yml, git.yml, chezmoi.yml, zsh.yml, user.yml)
 - **AUR support:** Dedicated `aur_builder` user for secure AUR package building
 - **Git automation:** Standardized, reusable task files for all common git operations
 - **Chezmoi integration:** Templates `.chezmoidata.yaml` for machine-specific dotfiles configuration
@@ -121,12 +121,13 @@ wt remove feature-name
 **Run playbook:**
 
 ```bash
-./run.sh                      # Run all roles (packages + ssh + git + chezmoi)
+./run.sh                      # Run all roles (packages + ssh + git + chezmoi + zsh)
 ./run.sh --check             # Dry-run mode
 ./run.sh --tags packages     # Run only package management
 ./run.sh --tags ssh          # Run only SSH configuration
 ./run.sh --tags git          # Run only Git configuration
 ./run.sh --tags chezmoi      # Run only Chezmoi configuration
+./run.sh --tags zsh          # Run only Zsh configuration
 ./run.sh --tags aur          # Run only AUR-related tasks
 ```
 
@@ -148,6 +149,7 @@ ansible-playbook playbook.yml --tags ssh --ask-vault-pass
 - ✅ **ssh** - SSH directory setup, key deployment, config management, known_hosts
 - ✅ **git** - Comprehensive Git configuration and repository management
 - ✅ **chezmoi** - Dotfiles management via machine-specific configuration templating
+- ✅ **zsh** - Modular shell configuration with numbered load-order directories
 - ✅ **cloudflared** - Cloudflare Tunnel with secure vault token storage
 
 **Features:**
@@ -173,6 +175,10 @@ ansible-playbook playbook.yml --tags ssh --ask-vault-pass
 - ✅ Cloudflare Tunnel token deployment from encrypted vault
 - ✅ Systemd service configuration with token-file (no plaintext secrets)
 - ✅ Cloudflared service enablement and management
+- ✅ Modular zsh configuration (29 files in numbered directories)
+- ✅ Minimal .zshrc with loader pattern
+- ✅ Deterministic load order (00-path through 90-skogai)
+- ✅ Auto-export for .env files
 - ⏸️ Additional system configuration (see `docs/system-inventory-by-primitives.md`)
 
 ## Packages Role Configuration
@@ -500,6 +506,65 @@ The Cloudflared role manages Cloudflare Tunnel with secure token storage using a
 
 **See also:** `docs/CLOUDFLARED_SETUP.md` for comprehensive setup guide.
 
+## Zsh Role Configuration
+
+The Zsh role deploys modular shell configuration with numbered load-order directories. All features are **configurable via vars/zsh.yml**.
+
+**Quick Start (Default behavior):**
+
+- Installs zsh package
+- Deploys `~/.config/zsh.d/` directory structure (29 files)
+- Creates minimal `.zshrc` that sources the loader
+
+**To customize zsh configuration:**
+
+1. Edit files in `roles/zsh/files/zsh.d/` directories
+2. Run: `./run.sh --tags zsh`
+
+**Directory Structure (zsh.d/):**
+
+```
+~/.config/zsh.d/
+├── loader.zsh           # Sources all config files
+├── 00-path/             # PATH exports (loads first)
+├── 10-settings/         # Shell settings (8 files)
+├── 20-functions/        # Shell functions (4 files)
+├── 30-aliases/          # Aliases (5 files)
+├── 40-completions/      # Completion config (2 files)
+├── 50-secrets/          # API keys (1 file)
+├── 60-exports/          # Environment exports (2 files)
+└── 90-skogai/           # SkogAI tools (5 files)
+```
+
+**loader.zsh Behavior:**
+
+- Sources `.zsh`, `.sh`, `.conf` files normally
+- Sources `.env` files with `allexport` (auto-exports all variables)
+
+**Available Zsh Features (configure in vars/zsh.yml):**
+
+- `zsh_install: true` - Install zsh package
+- `zsh_deploy_config: true` - Deploy zsh.d structure to ~/.config
+- `zsh_set_default_shell: false` - Set zsh as default shell
+
+**Granular tag support:**
+
+```bash
+./run.sh --tags zsh              # All zsh tasks
+./run.sh --tags zsh-install      # Only install zsh
+./run.sh --tags zsh-config       # Only deploy configuration
+./run.sh --tags zsh-default-shell # Only set default shell
+```
+
+**Design Decisions:**
+
+- **Minimal .zshrc** - Single line: `source ~/.config/zsh.d/loader.zsh`
+- **Ansible owns everything** - Chezmoi doesn't manage zsh config
+- **Numbered directories** - Deterministic load order (00 → 90)
+- **No plugin manager dependency** - Direct sourcing, no external deps
+
+**See:** `roles/zsh/README.md` for complete documentation.
+
 ## Reference
 
 ### Essential Reading
@@ -515,6 +580,7 @@ The Cloudflared role manages Cloudflare Tunnel with secure token storage using a
 - @roles/ssh/README.md - SSH role documentation
 - @roles/git/README.md - Git role documentation
 - @roles/cloudflared/README.md - Cloudflared role documentation
+- @roles/zsh/README.md - Zsh role documentation
 
 ### System Expansion
 

--- a/FILESTRUCTURE.md
+++ b/FILESTRUCTURE.md
@@ -87,15 +87,37 @@ SkogAI/skogansible/
 │   │   ├── handlers/main.yml            # Handlers for chezmoi role
 │   │   └── meta/main.yml                # Role metadata
 │   │
-│   └── cloudflared/                     # Cloudflare Tunnel management role
+│   ├── cloudflared/                     # Cloudflare Tunnel management role
+│   │   ├── tasks/
+│   │   │   └── main.yml                 # Cloudflared tasks (token deployment, service management)
+│   │   ├── templates/
+│   │   │   └── cloudflared.service.j2   # Systemd service template (uses --token-file)
+│   │   ├── defaults/main.yml            # Default variables for cloudflared role
+│   │   ├── handlers/main.yml            # Handlers for cloudflared role (daemon-reload, restart)
+│   │   ├── meta/main.yml                # Role metadata
+│   │   └── README.md                    # Complete Cloudflared role documentation
+│   │
+│   └── zsh/                             # Zsh shell configuration role
 │       ├── tasks/
-│       │   └── main.yml                 # Cloudflared tasks (token deployment, service management)
-│       ├── templates/
-│       │   └── cloudflared.service.j2   # Systemd service template (uses --token-file)
-│       ├── defaults/main.yml            # Default variables for cloudflared role
-│       ├── handlers/main.yml            # Handlers for cloudflared role (daemon-reload, restart)
+│       │   ├── main.yml                 # Zsh tasks orchestration
+│       │   ├── configure.yml            # Deploy zsh.d directory and .zshrc
+│       │   └── default_shell.yml        # Set zsh as default shell
+│       ├── files/
+│       │   └── zsh.d/                   # Modular zsh configuration (29 files)
+│       │       ├── loader.zsh           # Main loader (sources all config)
+│       │       ├── 00-path/             # PATH exports
+│       │       ├── 10-settings/         # Shell settings (8 files)
+│       │       ├── 20-functions/        # Shell functions (4 files)
+│       │       ├── 30-aliases/          # Aliases (5 files)
+│       │       ├── 40-completions/      # Completion config (2 files)
+│       │       ├── 50-secrets/          # API keys (1 file)
+│       │       ├── 60-exports/          # Environment exports (2 files)
+│       │       └── 90-skogai/           # SkogAI tools (5 files)
+│       ├── defaults/main.yml            # Default variables for zsh role
+│       ├── handlers/main.yml            # Handlers for zsh role
 │       ├── meta/main.yml                # Role metadata
-│       └── README.md                    # Complete Cloudflared role documentation
+│       ├── vars/main.yml                # Role variables
+│       └── README.md                    # Complete Zsh role documentation
 │
 ├── vars/                                # Variable files (role-specific configuration)
 │   ├── main.yml                         # Shared variables across roles
@@ -107,6 +129,7 @@ SkogAI/skogansible/
 │   ├── cloudflared.yml                  # Cloudflared configuration (deployment flags, extra args)
 │   ├── cloudflared_vault.yml            # Encrypted Cloudflare tunnel token (ansible-vault)
 │   ├── cloudflared_vault.yml.template   # Template for creating vault file
+│   ├── zsh.yml                          # Zsh role configuration (deploy flags)
 │   └── user.yml                         # User-specific variables (username, groups, shell)
 │
 ├── docs/                                # Documentation directory
@@ -205,6 +228,10 @@ Manages dotfiles by templating machine-specific .chezmoidata.yaml configuration 
 
 Manages Cloudflare Tunnel with secure token storage using ansible-vault. Deploys tunnel token from encrypted vault, configures systemd service with --token-file flag (no plaintext secrets), and manages service enablement.
 
+#### zsh/
+
+Manages zsh shell configuration with modular zsh.d structure. Deploys numbered configuration directories (00-path through 90-skogai) to ~/.config/zsh.d/ with a minimal .zshrc that sources the loader. Supports deterministic load order, .env files with auto-export, and clean separation of concerns.
+
 ### Variables
 
 All role-specific configuration stored in `vars/` directory:
@@ -217,6 +244,7 @@ All role-specific configuration stored in `vars/` directory:
 - **cloudflared.yml** - Cloudflared configuration (deployment flags, extra args)
 - **cloudflared_vault.yml** - Encrypted Cloudflare tunnel token (use ansible-vault to edit)
 - **cloudflared_vault.yml.template** - Template for creating vault file
+- **zsh.yml** - Zsh role configuration (deploy config, default shell flags)
 - **user.yml** - User-specific variables (username, groups, shell)
 - **main.yml** - Shared variables across all roles
 
@@ -249,9 +277,10 @@ The following directories are excluded from version control (see .gitignore):
 
 ## File Counts
 
-- **5 roles** - packages, ssh, git, chezmoi, cloudflared
-- **10 variable files** - Role-specific configuration
-- **13+ task files** - Modular task definitions
+- **6 roles** - packages, ssh, git, chezmoi, cloudflared, zsh
+- **11 variable files** - Role-specific configuration
+- **16+ task files** - Modular task definitions
+- **29 zsh config files** - Modular shell configuration in zsh.d/
 - **7+ templates** - Jinja2 templates for configs and hooks
 - **12+ documentation files** - Reference and historical docs
 - **3 collections** - Ansible Galaxy collections installed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Automated Arch Linux system configuration using Ansible with comprehensive role-
 - **SSH Configuration** - Key deployment, config templating, known_hosts management
 - **Git Configuration** - Complete git setup with aliases, hooks, signing, LFS support
 - **Chezmoi Integration** - Machine-specific dotfiles templating and deployment
+- **Zsh Configuration** - Modular shell config with numbered load-order directories
 - **Filesystem Mounts** - UUID-based filesystem mount management with fstab integration
 - **Security** - Dedicated AUR builder user, vault-encrypted secrets
 - **Documentation** - Primitives-based reference architecture and system inventory
@@ -30,6 +31,7 @@ Automated Arch Linux system configuration using Ansible with comprehensive role-
 ./run.sh --tags ssh           # Only SSH setup
 ./run.sh --tags git           # Only Git config
 ./run.sh --tags chezmoi       # Only Chezmoi
+./run.sh --tags zsh           # Only Zsh config
 ./run.sh --tags filesystems   # Only filesystem mounts
 ./run.sh --check              # Dry-run mode
 ```
@@ -39,7 +41,7 @@ Automated Arch Linux system configuration using Ansible with comprehensive role-
 ```
 SkogAI/skogansible/
 ├── playbooks/                # Ansible playbooks
-│   ├── default.yml           # Main playbook (5 roles)
+│   ├── default.yml           # Main playbook (6 roles)
 │   ├── workstation.yml       # Workstation setup
 │   └── ...                   # Additional playbooks
 ├── bootstrap.sh              # Initial setup script
@@ -49,12 +51,14 @@ SkogAI/skogansible/
 │   ├── ssh/                  # SSH configuration
 │   ├── git/                  # Git configuration
 │   ├── chezmoi/              # Dotfiles management
+│   ├── zsh/                  # Zsh shell configuration
 │   └── filesystems/          # Filesystem mounts management
 ├── vars/                     # Role-specific configuration
 │   ├── packages.yml          # Package lists
 │   ├── ssh.yml               # SSH settings
 │   ├── git.yml               # Git settings
 │   ├── chezmoi.yml           # Chezmoi settings
+│   ├── zsh.yml               # Zsh settings
 │   ├── filesystems.yml       # Filesystem mount definitions
 │   └── user.yml              # User variables
 └── docs/                     # Reference documentation
@@ -81,6 +85,7 @@ All role-specific configuration is in `vars/` directory:
 - **ssh.yml** - Enable/disable SSH features (keys, config, known_hosts)
 - **git.yml** - Configure git settings (user, aliases, hooks, signing)
 - **chezmoi.yml** - Machine profile settings (type, WM, laptop mode)
+- **zsh.yml** - Zsh configuration (deploy config, default shell)
 - **filesystems.yml** - Define filesystem mounts (UUID, path, fstype, options)
 
 Each role has comprehensive documentation in its `README.md` file.
@@ -102,7 +107,7 @@ This is the main active ansible repository for SkogAI. Historical documentation 
 - **Active Repository:** SkogAI/skogansible
 - **Purpose:** Main ansible automation for Arch Linux system configuration
 - **Approach:** Primitives-based role architecture with comprehensive documentation
-- **Status:** 5 roles implemented (packages, ssh, git, chezmoi, filesystems), system expansion roadmap documented
+- **Status:** 6 roles implemented (packages, ssh, git, chezmoi, zsh, filesystems), system expansion roadmap documented
 
 ---
 

--- a/roles/zsh/README.md
+++ b/roles/zsh/README.md
@@ -1,44 +1,94 @@
 # Ansible Role: zsh
 
-Zsh shell installation and configuration management.
+Modular zsh configuration deployment with numbered load-order directories.
 
-This role provides:
+## What It Does
 
-- Zsh installation
-- Configuration file deployment
-- Default shell setup
-- Plugin manager integration (zinit, oh-my-zsh, etc.)
+- Deploys `~/.config/zsh.d/` directory structure with modular configuration
+- Creates minimal `.zshrc` (single line: `source ~/.config/zsh.d/loader.zsh`)
+- Optionally sets zsh as default shell
 
 ## Requirements
 
 - Ansible 2.10 or higher
 - Target system: Arch Linux
 
+## Directory Structure (zsh.d/)
+
+The role deploys a modular zsh configuration organized by numbered directories for deterministic load order:
+
+```
+~/.config/zsh.d/
+├── loader.zsh           # Main loader that sources everything
+├── 00-path/             # PATH exports (loads first)
+│   └── path.zsh
+├── 10-settings/         # Shell settings (8 files)
+│   ├── grc.zsh          # Generic colorizer setup
+│   ├── history.zsh      # History configuration
+│   ├── keybindings.zsh  # Key bindings (emacs mode)
+│   ├── nvm.zsh          # Node Version Manager
+│   ├── options.zsh      # Shell options (setopt)
+│   ├── prompt.zsh       # Prompt configuration
+│   ├── shell-enhancements.zsh  # Enhanced tools (zoxide, etc.)
+│   └── zplug.zsh        # Plugin manager
+├── 20-functions/        # Shell functions (4 files)
+│   ├── docker.zsh       # Docker helper functions
+│   ├── git.zsh          # Git helper functions
+│   ├── python.zsh       # Python/venv functions
+│   └── utils.zsh        # General utilities
+├── 30-aliases/          # Aliases (5 files)
+│   ├── build.zsh        # Build tool aliases
+│   ├── git.zsh          # Git aliases
+│   ├── navigation.zsh   # Directory navigation
+│   ├── system.zsh       # System management
+│   └── tools.zsh        # Tool aliases (eza, bat, etc.)
+├── 40-completions/      # Completion config (2 files)
+│   ├── argc.zsh         # argc completions
+│   └── completions.zsh  # zstyle completion settings
+├── 50-secrets/          # API keys (1 file)
+│   └── openrouter.zsh   # OpenRouter API key
+├── 60-exports/          # Environment exports (2 files)
+│   ├── editor.zsh       # EDITOR/VISUAL
+│   └── fzf.zsh          # FZF configuration
+└── 90-skogai/           # SkogAI tools (5 files)
+    ├── ai.zsh           # AI tool wrappers
+    ├── aichat.zsh       # aichat configuration
+    ├── dev.zsh          # Development helpers
+    ├── skogai.zsh       # SkogAI paths
+    └── skogcli.zsh      # skogcli integration
+```
+
+## loader.zsh Behavior
+
+The loader sources files in directory order (00 → 90) with special handling:
+
+- **`.zsh`, `.sh`, `.conf` files** → Sourced normally
+- **`.env` files** → Sourced with `allexport` (auto-exports all variables)
+
+```zsh
+# loader.zsh behavior
+for dir in "$zsh_d"/[0-9]*(/N); do
+    for file in "$dir"/*.(zsh|sh|conf)(N); do
+        source "$file"
+    done
+    for file in "$dir"/*.env(N); do
+        set -o allexport
+        source "$file"
+        set +o allexport
+    done
+done
+```
+
 ## Role Variables
 
-All role variables are defined in `defaults/main.yml` with sensible defaults. Override them in your playbook, inventory, or `vars/zsh.yml`.
+All variables defined in `defaults/main.yml` with sensible defaults. Override in `vars/zsh.yml`.
 
-### Installation
-
-```yaml
-zsh_install: true              # Install zsh
-zsh_package_name: "zsh"        # Package name
-```
-
-### Configuration
-
-```yaml
-zsh_deploy_config: false       # Deploy configuration file
-zsh_config_file: "{{ ansible_facts['env']['HOME'] }}/.zshrc"
-```
-
-### Feature Flags
-
-```yaml
-zsh_set_default_shell: false   # Set zsh as default shell
-zsh_enable_plugin_manager: false  # Enable plugin manager
-zsh_plugin_manager: "zinit"    # Plugin manager to use
-```
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `zsh_install` | `true` | Install zsh package |
+| `zsh_package_name` | `zsh` | Package name to install |
+| `zsh_deploy_config` | `true` | Deploy zsh.d structure to ~/.config |
+| `zsh_set_default_shell` | `false` | Set zsh as user's default shell |
 
 ## Dependencies
 
@@ -46,7 +96,7 @@ None
 
 ## Example Playbook
 
-### Basic Usage
+### Basic Usage (deploy config only)
 
 ```yaml
 - hosts: localhost
@@ -54,9 +104,10 @@ None
     - role: zsh
       vars:
         zsh_install: true
+        zsh_deploy_config: true
 ```
 
-### Full Setup
+### Full Setup (with default shell)
 
 ```yaml
 - hosts: localhost
@@ -66,8 +117,6 @@ None
         zsh_install: true
         zsh_deploy_config: true
         zsh_set_default_shell: true
-        zsh_enable_plugin_manager: true
-        zsh_plugin_manager: "zinit"
 ```
 
 ## Tags
@@ -78,26 +127,62 @@ Run specific parts of the role:
 # Run entire role
 ./run.sh --tags zsh
 
-# Run only installation
+# Only install zsh package
 ./run.sh --tags zsh-install
 
-# Run only configuration
+# Only deploy zsh.d configuration
 ./run.sh --tags zsh-config
 
-# Set default shell
+# Only set default shell
 ./run.sh --tags zsh-default-shell
-
-# Setup plugins
-./run.sh --tags zsh-plugins
 ```
 
 Available tags:
 
 - `zsh` - Run all tasks
-- `zsh-install` - Installation tasks
-- `zsh-config` - Configuration tasks
-- `zsh-default-shell` - Default shell tasks
-- `zsh-plugins` - Plugin manager tasks
+- `zsh-install` - Install zsh package
+- `zsh-config` - Deploy zsh.d directory and .zshrc
+- `zsh-default-shell` - Set zsh as default shell
+
+## Design Decisions
+
+### Why Modular zsh.d?
+
+1. **Maintainability** - Each concern in separate files
+2. **Deterministic loading** - Numbered directories ensure correct order
+3. **Easy debugging** - Isolate issues to specific files
+4. **No plugin manager dependency** - Direct sourcing, no external deps
+
+### Why Minimal .zshrc?
+
+The `.zshrc` contains only: `source ~/.config/zsh.d/loader.zsh`
+
+- **Single source of truth** - All config in zsh.d
+- **No conflicts** - Chezmoi doesn't manage zsh config
+- **Ansible owns everything** - Clear ownership boundary
+
+### Why .env with allexport?
+
+Files ending in `.env` are sourced with `set -o allexport` which automatically exports all variables. This allows:
+
+- Clean separation of secrets (API keys, tokens)
+- Standard `.env` file format
+- Automatic export without `export` prefix
+
+## Customization
+
+### Adding New Configuration
+
+1. Choose appropriate directory (00-90 based on load order needs)
+2. Create `.zsh` file with your config
+3. Run `./run.sh --tags zsh-config` to deploy
+
+### Secrets Management
+
+Place sensitive exports in `50-secrets/` directory. Files here are deployed but should be:
+
+- Not committed to version control (add to .gitignore if needed)
+- Deployed from encrypted vault for production
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrite `roles/zsh/README.md` with actual modular zsh.d architecture documentation
- Add zsh role structure and description to `FILESTRUCTURE.md`
- Add zsh to features, roles list, and usage in `README.md`
- Add Zsh Role Configuration section to `CLAUDE.md`

## Changes

The zsh role was implemented in commit `caf87bc` but documentation was still from the template and didn't reflect the actual implementation. This PR updates all documentation to accurately describe:

- Modular zsh.d directory structure (00-path through 90-skogai)
- loader.zsh behavior (normal sourcing + .env with allexport)
- Design decisions (minimal .zshrc, Ansible owns everything, no plugin manager dependency)
- Available tags and configuration options

## Files Changed

| File | Change |
|------|--------|
| `roles/zsh/README.md` | Complete rewrite with actual architecture |
| `FILESTRUCTURE.md` | Added zsh role structure and description |
| `README.md` | Added zsh to features, roles, usage |
| `CLAUDE.md` | Added Zsh Role Configuration section |