### PR TITLE
feat: Add graphics role for GPU drivers and Ollama management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,12 +121,13 @@ wt remove feature-name
 **Run playbook:**
 
 ```bash
-./run.sh                      # Run all roles (packages + ssh + git + chezmoi)
+./run.sh                      # Run all roles (packages + ssh + git + chezmoi + graphics)
 ./run.sh --check             # Dry-run mode
 ./run.sh --tags packages     # Run only package management
 ./run.sh --tags ssh          # Run only SSH configuration
 ./run.sh --tags git          # Run only Git configuration
 ./run.sh --tags chezmoi      # Run only Chezmoi configuration
+./run.sh --tags graphics     # Run only GPU drivers and Ollama
 ./run.sh --tags aur          # Run only AUR-related tasks
 ```
 
@@ -149,6 +150,7 @@ ansible-playbook playbook.yml --tags ssh --ask-vault-pass
 - ✅ **git** - Comprehensive Git configuration and repository management
 - ✅ **chezmoi** - Dotfiles management via machine-specific configuration templating
 - ✅ **cloudflared** - Cloudflare Tunnel with secure vault token storage
+- ✅ **graphics** - GPU drivers (NVIDIA/AMD/Intel) and Ollama AI model management
 
 **Features:**
 
@@ -173,6 +175,10 @@ ansible-playbook playbook.yml --tags ssh --ask-vault-pass
 - ✅ Cloudflare Tunnel token deployment from encrypted vault
 - ✅ Systemd service configuration with token-file (no plaintext secrets)
 - ✅ Cloudflared service enablement and management
+- ✅ GPU driver installation (NVIDIA, AMD, Intel)
+- ✅ CUDA toolkit installation (optional)
+- ✅ Ollama AI model installation and service management
+- ✅ Automatic initramfs regeneration after driver changes
 - ⏸️ Additional system configuration (see `docs/system-inventory-by-primitives.md`)
 
 ## Packages Role Configuration
@@ -500,6 +506,80 @@ The Cloudflared role manages Cloudflare Tunnel with secure token storage using a
 
 **See also:** `docs/CLOUDFLARED_SETUP.md` for comprehensive setup guide.
 
+## Graphics Role Configuration
+
+The Graphics role manages GPU drivers and Ollama AI model infrastructure for Arch Linux systems.
+
+**Quick Start (Default behavior):**
+
+- Installs GPU drivers based on `graphics_driver` selection (nvidia/amd/intel/none)
+- Optionally installs CUDA toolkit (NVIDIA only)
+- Installs Ollama AI model server
+- Enables and starts Ollama service
+- Pulls specified AI models
+- Regenerates initramfs after driver installation
+
+**To configure graphics:**
+
+1. Edit `vars/graphics.yml` to set your GPU driver:
+
+   ```yaml
+   graphics_driver: nvidia  # Options: nvidia, amd, intel, none
+   graphics_install_cuda: false
+   graphics_install_ollama: true
+   graphics_ollama_models:
+     - llama2
+     - codellama
+   ```
+
+2. Run: `./run.sh --tags graphics`
+
+**Available Graphics Features (configure in vars/graphics.yml):**
+
+- `graphics_driver: "nvidia|amd|intel|none"` - GPU driver selection
+- `graphics_install_cuda: false` - Install CUDA toolkit (NVIDIA only)
+- `graphics_install_ollama: true` - Install Ollama AI server
+- `graphics_ollama_method: "pacman"` - Installation method (pacman or script)
+- `graphics_ollama_enable_service: true` - Enable Ollama systemd service
+- `graphics_ollama_models: []` - List of AI models to pull after installation
+- `graphics_regenerate_initramfs: true` - Regenerate initramfs after driver changes
+
+**GPU Driver Packages:**
+
+- **NVIDIA**: nvidia, nvidia-utils, lib32-nvidia-utils
+- **AMD**: xf86-video-amdgpu, vulkan-radeon, lib32-vulkan-radeon
+- **Intel**: xf86-video-intel, vulkan-intel, lib32-vulkan-intel
+
+**Granular tag support:**
+
+```bash
+./run.sh --tags graphics           # All graphics tasks
+./run.sh --tags graphics,drivers   # Only GPU drivers
+./run.sh --tags graphics,cuda      # Only CUDA toolkit
+./run.sh --tags graphics,ollama    # Only Ollama installation
+./run.sh --tags graphics,initramfs # Only initramfs regeneration
+```
+
+**How it works:**
+
+1. Installs GPU drivers based on `graphics_driver` variable
+2. Optionally installs CUDA toolkit (if enabled and NVIDIA driver selected)
+3. Installs Ollama via pacman or install script
+4. Enables and starts Ollama systemd service
+5. Waits for Ollama to be ready (port 11434)
+6. Pulls specified AI models
+7. Regenerates initramfs with `mkinitcpio -P`
+8. Notifies that system reboot is required
+
+**Important Notes:**
+
+- **System reboot required** after GPU driver installation
+- CUDA toolkit requires NVIDIA drivers (`graphics_driver: nvidia`)
+- Ollama models can be large (4GB - 70GB per model)
+- First model pull can take 10-60 minutes depending on connection speed
+
+**See:** `roles/graphics/README.md` for complete documentation and troubleshooting.
+
 ## Reference
 
 ### Essential Reading
@@ -515,6 +595,7 @@ The Cloudflared role manages Cloudflare Tunnel with secure token storage using a
 - @roles/ssh/README.md - SSH role documentation
 - @roles/git/README.md - Git role documentation
 - @roles/cloudflared/README.md - Cloudflared role documentation
+- @roles/graphics/README.md - Graphics role documentation
 
 ### System Expansion
 

--- a/FILESTRUCTURE.md
+++ b/FILESTRUCTURE.md
@@ -87,15 +87,26 @@ SkogAI/skogansible/
 │   │   ├── handlers/main.yml            # Handlers for chezmoi role
 │   │   └── meta/main.yml                # Role metadata
 │   │
-│   └── cloudflared/                     # Cloudflare Tunnel management role
+│   ├── cloudflared/                     # Cloudflare Tunnel management role
+│   │   ├── tasks/
+│   │   │   └── main.yml                 # Cloudflared tasks (token deployment, service management)
+│   │   ├── templates/
+│   │   │   └── cloudflared.service.j2   # Systemd service template (uses --token-file)
+│   │   ├── defaults/main.yml            # Default variables for cloudflared role
+│   │   ├── handlers/main.yml            # Handlers for cloudflared role (daemon-reload, restart)
+│   │   ├── meta/main.yml                # Role metadata
+│   │   └── README.md                    # Complete Cloudflared role documentation
+│   │
+│   └── graphics/                        # GPU drivers and Ollama management role
 │       ├── tasks/
-│       │   └── main.yml                 # Cloudflared tasks (token deployment, service management)
-│       ├── templates/
-│       │   └── cloudflared.service.j2   # Systemd service template (uses --token-file)
-│       ├── defaults/main.yml            # Default variables for cloudflared role
-│       ├── handlers/main.yml            # Handlers for cloudflared role (daemon-reload, restart)
+│       │   ├── main.yml                 # Graphics tasks orchestration
+│       │   ├── drivers.yml              # GPU driver installation (NVIDIA/AMD/Intel)
+│       │   ├── cuda.yml                 # CUDA toolkit installation
+│       │   └── ollama.yml               # Ollama installation and model management
+│       ├── defaults/main.yml            # Default variables for graphics role
+│       ├── handlers/main.yml            # Handlers for graphics role (initramfs regeneration)
 │       ├── meta/main.yml                # Role metadata
-│       └── README.md                    # Complete Cloudflared role documentation
+│       └── README.md                    # Complete Graphics role documentation
 │
 ├── vars/                                # Variable files (role-specific configuration)
 │   ├── main.yml                         # Shared variables across roles
@@ -107,6 +118,7 @@ SkogAI/skogansible/
 │   ├── cloudflared.yml                  # Cloudflared configuration (deployment flags, extra args)
 │   ├── cloudflared_vault.yml            # Encrypted Cloudflare tunnel token (ansible-vault)
 │   ├── cloudflared_vault.yml.template   # Template for creating vault file
+│   ├── graphics.yml                     # Graphics configuration (GPU driver, CUDA, Ollama models)
 │   └── user.yml                         # User-specific variables (username, groups, shell)
 │
 ├── docs/                                # Documentation directory
@@ -169,7 +181,7 @@ SkogAI/skogansible/
 
 ### Playbooks
 
-- **playbook.yml** - Main playbook that orchestrates all 4 roles (packages, ssh, git, chezmoi) with proper variable loading
+- **playbook.yml** - Main playbook that orchestrates all roles (packages, ssh, git, chezmoi, cloudflared, graphics) with proper variable loading
 
 ### Documentation
 
@@ -205,6 +217,10 @@ Manages dotfiles by templating machine-specific .chezmoidata.yaml configuration 
 
 Manages Cloudflare Tunnel with secure token storage using ansible-vault. Deploys tunnel token from encrypted vault, configures systemd service with --token-file flag (no plaintext secrets), and manages service enablement.
 
+#### graphics/
+
+Manages GPU drivers and Ollama AI model infrastructure. Installs NVIDIA/AMD/Intel drivers, optional CUDA toolkit, Ollama service, and pulls AI models. Automatically regenerates initramfs after driver changes.
+
 ### Variables
 
 All role-specific configuration stored in `vars/` directory:
@@ -217,6 +233,7 @@ All role-specific configuration stored in `vars/` directory:
 - **cloudflared.yml** - Cloudflared configuration (deployment flags, extra args)
 - **cloudflared_vault.yml** - Encrypted Cloudflare tunnel token (use ansible-vault to edit)
 - **cloudflared_vault.yml.template** - Template for creating vault file
+- **graphics.yml** - Graphics configuration (GPU driver selection, CUDA, Ollama models)
 - **user.yml** - User-specific variables (username, groups, shell)
 - **main.yml** - Shared variables across all roles
 
@@ -249,11 +266,11 @@ The following directories are excluded from version control (see .gitignore):
 
 ## File Counts
 
-- **5 roles** - packages, ssh, git, chezmoi, cloudflared
-- **10 variable files** - Role-specific configuration
-- **13+ task files** - Modular task definitions
+- **6 roles** - packages, ssh, git, chezmoi, cloudflared, graphics
+- **11 variable files** - Role-specific configuration
+- **17+ task files** - Modular task definitions
 - **7+ templates** - Jinja2 templates for configs and hooks
-- **12+ documentation files** - Reference and historical docs
+- **13+ documentation files** - Reference and historical docs
 - **3 collections** - Ansible Galaxy collections installed
 
 ---

--- a/playbooks/workstation.yml
+++ b/playbooks/workstation.yml
@@ -15,6 +15,7 @@
     - ../vars/cloudflared.yml
     - ../vars/cloudflared_vault.yml
     - ../vars/filesystems.yml
+    - ../vars/graphics.yml
 
   roles:
     - role: packages
@@ -34,3 +35,6 @@
 
     - role: filesystems
       tags: [filesystems, mounts]
+
+    - role: graphics
+      tags: [graphics, gpu, ollama]

--- a/roles/graphics/README.md
+++ b/roles/graphics/README.md
@@ -1,0 +1,528 @@
+# Ansible Role: Graphics
+
+GPU driver and Ollama management role for Arch Linux systems.
+
+This role provides automated GPU driver installation and Ollama AI model management including:
+
+- NVIDIA driver installation (nvidia, nvidia-utils, lib32-nvidia-utils)
+- AMD driver installation (xf86-video-amdgpu, vulkan-radeon)
+- Intel driver installation (xf86-video-intel, vulkan-intel)
+- CUDA toolkit installation (optional)
+- Ollama installation (pacman or script method)
+- Ollama service management
+- Ollama model pulling
+- Automatic initramfs regeneration
+
+## Requirements
+
+- Ansible 2.10 or higher
+- `community.general` collection (for `pacman` module)
+- Target system: Arch Linux
+- User must have sudo privileges
+
+## Role Variables
+
+All role variables are defined in `defaults/main.yml` with sensible defaults. Override them in your playbook, inventory, or `vars/graphics.yml`.
+
+### GPU Driver Selection
+
+```yaml
+graphics_driver: "none"          # Options: nvidia, amd, intel, none
+```
+
+### NVIDIA Drivers
+
+```yaml
+graphics_nvidia_packages:
+  - nvidia
+  - nvidia-utils
+  - lib32-nvidia-utils
+```
+
+### AMD Drivers
+
+```yaml
+graphics_amd_packages:
+  - xf86-video-amdgpu
+  - vulkan-radeon
+  - lib32-vulkan-radeon
+```
+
+### Intel Drivers
+
+```yaml
+graphics_intel_packages:
+  - xf86-video-intel
+  - vulkan-intel
+  - lib32-vulkan-intel
+```
+
+### CUDA Toolkit
+
+```yaml
+graphics_install_cuda: false     # Install CUDA toolkit (requires nvidia driver)
+graphics_cuda_packages:
+  - cuda
+  - cudnn
+```
+
+### Ollama Installation
+
+```yaml
+graphics_install_ollama: true
+graphics_ollama_method: "pacman"           # Options: pacman, script
+graphics_ollama_script_url: "https://ollama.ai/install.sh"
+```
+
+### Ollama Service
+
+```yaml
+graphics_ollama_enable_service: true
+graphics_ollama_service_state: "started"   # Options: started, stopped
+```
+
+### Ollama Models
+
+```yaml
+graphics_ollama_models: []       # List of models to pull after installation
+# Example:
+# graphics_ollama_models:
+#   - llama2
+#   - codellama
+#   - mistral
+```
+
+### System Configuration
+
+```yaml
+graphics_regenerate_initramfs: true   # Regenerate initramfs after driver installation
+```
+
+## Dependencies
+
+None.
+
+## Example Playbooks
+
+### Basic NVIDIA Setup
+
+Install NVIDIA drivers and Ollama:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "nvidia"
+        graphics_install_ollama: true
+        graphics_ollama_models:
+          - llama2
+```
+
+### AMD with CUDA Disabled
+
+Install AMD drivers without CUDA:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "amd"
+        graphics_install_cuda: false
+        graphics_install_ollama: true
+```
+
+### NVIDIA with CUDA
+
+Install NVIDIA drivers, CUDA toolkit, and Ollama:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "nvidia"
+        graphics_install_cuda: true
+        graphics_install_ollama: true
+        graphics_ollama_models:
+          - llama2
+          - codellama
+          - mistral
+```
+
+### Intel Graphics
+
+Install Intel drivers:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "intel"
+        graphics_install_ollama: false
+```
+
+### Ollama Only (No GPU Drivers)
+
+Install and configure Ollama without GPU driver changes:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "none"
+        graphics_install_ollama: true
+        graphics_ollama_method: "script"
+        graphics_ollama_models:
+          - llama2
+```
+
+### With Variables File
+
+Using `vars/graphics.yml`:
+
+```yaml
+- hosts: localhost
+  vars_files:
+    - vars/graphics.yml
+  roles:
+    - graphics
+  tags:
+    - graphics
+```
+
+## Role Tasks
+
+The role executes tasks in this order:
+
+### 1. Driver Installation (`drivers.yml`)
+
+Installs GPU drivers based on `graphics_driver` selection:
+
+- **NVIDIA**: Installs nvidia, nvidia-utils, lib32-nvidia-utils
+- **AMD**: Installs xf86-video-amdgpu, vulkan-radeon, lib32-vulkan-radeon
+- **Intel**: Installs xf86-video-intel, vulkan-intel, lib32-vulkan-intel
+
+Notifies `Regenerate initramfs` handler after driver installation.
+
+### 2. CUDA Installation (`cuda.yml`)
+
+Installs CUDA toolkit if enabled:
+
+- Verifies NVIDIA drivers are installed
+- Installs cuda and cudnn packages
+
+**Note**: CUDA requires NVIDIA drivers (`graphics_driver: nvidia`).
+
+### 3. Ollama Installation (`ollama.yml`)
+
+Installs and configures Ollama:
+
+- Installs Ollama via pacman or install script
+- Enables and starts Ollama systemd service
+- Waits for Ollama to be ready (port 11434)
+- Pulls specified models
+
+### 4. Initramfs Regeneration
+
+Regenerates initramfs after driver installation:
+
+- Runs `mkinitcpio -P` to rebuild initramfs
+- Notifies that system reboot is required
+
+## Tags
+
+The role supports granular execution via tags:
+
+- `graphics` - All graphics tasks
+- `drivers` - GPU driver installation only
+- `cuda` - CUDA toolkit installation only
+- `ollama` - Ollama installation and configuration only
+- `initramfs` - Initramfs regeneration only
+
+### Tag Usage Examples
+
+```bash
+# Install only GPU drivers
+ansible-playbook playbooks/workstation.yml --tags graphics,drivers
+
+# Install only Ollama
+ansible-playbook playbooks/workstation.yml --tags graphics,ollama
+
+# Full graphics setup
+ansible-playbook playbooks/workstation.yml --tags graphics
+```
+
+## Variables File Example
+
+Create `vars/graphics.yml`:
+
+```yaml
+---
+# GPU driver selection
+graphics_driver: "nvidia"
+
+# CUDA toolkit
+graphics_install_cuda: false
+
+# Ollama configuration
+graphics_install_ollama: true
+graphics_ollama_method: "pacman"
+graphics_ollama_enable_service: true
+graphics_ollama_service_state: "started"
+
+# Ollama models
+graphics_ollama_models:
+  - llama2
+  - codellama
+  - mistral
+
+# System configuration
+graphics_regenerate_initramfs: true
+```
+
+## Handlers
+
+### Regenerate initramfs
+
+Triggered after driver installation:
+
+```yaml
+- name: Regenerate initramfs
+  become: true
+  ansible.builtin.command:
+    cmd: mkinitcpio -P
+```
+
+### Reboot required
+
+Displays warning that system reboot is required:
+
+```yaml
+- name: Reboot required
+  ansible.builtin.debug:
+    msg: "⚠️  System reboot required for GPU driver changes to take effect"
+```
+
+## Security Considerations
+
+### Driver Installation
+
+GPU driver installation requires:
+
+- Sudo privileges (`become: true`)
+- System reboot after installation
+- Initramfs regeneration
+
+### Ollama Installation
+
+Ollama can be installed via:
+
+- **pacman** (recommended): Official Arch package
+- **script**: Downloads and runs install script from ollama.ai
+
+The script method executes remote code. Review the script before using:
+
+```bash
+curl -fsSL https://ollama.ai/install.sh | less
+```
+
+### CUDA Requirements
+
+CUDA toolkit requires NVIDIA drivers. The role will fail if CUDA is enabled without `graphics_driver: nvidia`.
+
+## Troubleshooting
+
+### Driver Installation Fails
+
+Check system compatibility:
+
+```bash
+# NVIDIA
+lspci | grep -i nvidia
+
+# AMD
+lspci | grep -i amd
+
+# Intel
+lspci | grep -i intel
+```
+
+### Initramfs Regeneration Fails
+
+Manually regenerate:
+
+```bash
+sudo mkinitcpio -P
+```
+
+Check for errors in `/var/log/pacman.log`.
+
+### Ollama Service Won't Start
+
+Check service status:
+
+```bash
+sudo systemctl status ollama
+journalctl -u ollama -f
+```
+
+Verify Ollama installation:
+
+```bash
+which ollama
+ollama --version
+```
+
+### CUDA Installation Fails
+
+Ensure NVIDIA drivers are installed:
+
+```bash
+nvidia-smi
+```
+
+Verify CUDA compatibility with GPU:
+
+```bash
+lspci | grep -i nvidia
+# Check GPU model against CUDA compatibility list
+```
+
+### Ollama Model Pull Fails
+
+Check Ollama service is running:
+
+```bash
+systemctl status ollama
+```
+
+Manually pull model:
+
+```bash
+ollama pull llama2
+```
+
+Check disk space:
+
+```bash
+df -h
+```
+
+## Post-Installation
+
+### After Driver Installation
+
+**System reboot required** for GPU driver changes to take effect:
+
+```bash
+sudo reboot
+```
+
+### Verify GPU Driver
+
+After reboot, verify driver is loaded:
+
+```bash
+# NVIDIA
+nvidia-smi
+
+# AMD
+glxinfo | grep -i amd
+
+# Intel
+glxinfo | grep -i intel
+```
+
+### Verify Ollama
+
+Check Ollama is running:
+
+```bash
+systemctl status ollama
+ollama list  # List installed models
+```
+
+Test a model:
+
+```bash
+ollama run llama2
+```
+
+## File Structure
+
+```
+roles/graphics/
+├── defaults/
+│   └── main.yml              # Default variables
+├── tasks/
+│   ├── main.yml              # Main task orchestrator
+│   ├── drivers.yml           # GPU driver installation
+│   ├── cuda.yml              # CUDA toolkit installation
+│   └── ollama.yml            # Ollama installation and configuration
+├── handlers/
+│   └── main.yml              # Initramfs regeneration handler
+├── meta/
+│   └── main.yml              # Role metadata
+└── README.md                 # This file
+```
+
+## Integration with Playbook
+
+Add graphics role to your playbook:
+
+```yaml
+---
+- name: System configuration
+  hosts: localhost
+  connection: local
+
+  vars_files:
+    - vars/main.yml
+    - vars/packages.yml
+    - vars/graphics.yml
+
+  roles:
+    - packages
+    - graphics
+
+  tags:
+    - all
+```
+
+## Performance Considerations
+
+### Driver Installation
+
+- Large packages (nvidia, cuda): 500MB - 3GB download
+- Installation time: 2-10 minutes depending on connection speed
+
+### Ollama Installation
+
+- Ollama package: ~50MB
+- Model downloads: 4GB - 70GB per model
+- First model pull can take 10-60 minutes
+
+### Initramfs Regeneration
+
+- Time: 10-30 seconds
+- Required for driver changes to take effect
+
+## Further Reading
+
+- **NVIDIA on Arch Wiki**: https://wiki.archlinux.org/title/NVIDIA
+- **AMD on Arch Wiki**: https://wiki.archlinux.org/title/AMDGPU
+- **Intel Graphics**: https://wiki.archlinux.org/title/Intel_graphics
+- **CUDA**: https://wiki.archlinux.org/title/GPGPU
+- **Ollama Documentation**: https://ollama.ai/docs
+
+## License
+
+MIT
+
+## Author
+
+SkogAI (skogansible repository)

--- a/roles/graphics/defaults/main.yml
+++ b/roles/graphics/defaults/main.yml
@@ -1,0 +1,49 @@
+---
+# Default variables for graphics role
+
+# GPU driver selection
+# Options: nvidia, amd, intel, none
+graphics_driver: "none"
+
+# NVIDIA driver packages
+graphics_nvidia_packages:
+  - nvidia
+  - nvidia-utils
+  - lib32-nvidia-utils
+
+# AMD driver packages
+graphics_amd_packages:
+  - xf86-video-amdgpu
+  - vulkan-radeon
+  - lib32-vulkan-radeon
+
+# Intel driver packages
+graphics_intel_packages:
+  - xf86-video-intel
+  - vulkan-intel
+  - lib32-vulkan-intel
+
+# CUDA toolkit installation
+graphics_install_cuda: false
+graphics_cuda_packages:
+  - cuda
+  - cudnn
+
+# Ollama installation
+graphics_install_ollama: true
+graphics_ollama_method: "pacman"  # Options: pacman, script
+graphics_ollama_script_url: "https://ollama.ai/install.sh"
+
+# Ollama service management
+graphics_ollama_enable_service: true
+graphics_ollama_service_state: "started"
+
+# Ollama models to pull
+graphics_ollama_models: []
+# Example:
+# graphics_ollama_models:
+#   - llama2
+#   - codellama
+
+# Initramfs regeneration
+graphics_regenerate_initramfs: true

--- a/roles/graphics/handlers/main.yml
+++ b/roles/graphics/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+# Graphics Role - Handlers
+
+- name: Regenerate initramfs
+  become: true
+  ansible.builtin.command:
+    cmd: mkinitcpio -P
+  listen: Regenerate initramfs
+
+- name: Reboot required
+  ansible.builtin.debug:
+    msg: "⚠️  System reboot required for GPU driver changes to take effect"
+  listen: Reboot required

--- a/roles/graphics/meta/main.yml
+++ b/roles/graphics/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  author: SkogAI
+  description: GPU driver and Ollama management for Arch Linux
+  company: SkogAI
+  license: MIT
+  min_ansible_version: "2.10"
+  platforms:
+    - name: Archlinux
+      versions:
+        - all
+
+dependencies: []

--- a/roles/graphics/tasks/cuda.yml
+++ b/roles/graphics/tasks/cuda.yml
@@ -1,0 +1,17 @@
+---
+# CUDA Toolkit Installation Tasks
+
+- name: Verify NVIDIA drivers are installed
+  ansible.builtin.fail:
+    msg: "CUDA toolkit requires NVIDIA drivers. Please set graphics_driver: nvidia"
+  when: graphics_driver != "nvidia"
+
+- name: Install CUDA toolkit packages
+  become: true
+  community.general.pacman:
+    name: "{{ graphics_cuda_packages }}"
+    state: present
+
+- name: Display CUDA installation complete message
+  ansible.builtin.debug:
+    msg: "CUDA toolkit installed successfully"

--- a/roles/graphics/tasks/drivers.yml
+++ b/roles/graphics/tasks/drivers.yml
@@ -1,0 +1,31 @@
+---
+# GPU Driver Installation Tasks
+
+- name: Install NVIDIA drivers
+  become: true
+  community.general.pacman:
+    name: "{{ graphics_nvidia_packages }}"
+    state: present
+  when: graphics_driver == "nvidia"
+  notify: Regenerate initramfs
+
+- name: Install AMD drivers
+  become: true
+  community.general.pacman:
+    name: "{{ graphics_amd_packages }}"
+    state: present
+  when: graphics_driver == "amd"
+  notify: Regenerate initramfs
+
+- name: Install Intel drivers
+  become: true
+  community.general.pacman:
+    name: "{{ graphics_intel_packages }}"
+    state: present
+  when: graphics_driver == "intel"
+  notify: Regenerate initramfs
+
+- name: Display driver installation complete message
+  ansible.builtin.debug:
+    msg: "{{ graphics_driver | upper }} drivers installed successfully"
+  when: graphics_driver in ['nvidia', 'amd', 'intel']

--- a/roles/graphics/tasks/main.yml
+++ b/roles/graphics/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+# Graphics Role - Main Tasks
+
+- name: Install GPU drivers
+  ansible.builtin.include_tasks: drivers.yml
+  when: graphics_driver != "none"
+  tags: [graphics, drivers]
+
+- name: Install CUDA toolkit
+  ansible.builtin.include_tasks: cuda.yml
+  when: graphics_install_cuda
+  tags: [graphics, cuda]
+
+- name: Install and configure Ollama
+  ansible.builtin.include_tasks: ollama.yml
+  when: graphics_install_ollama
+  tags: [graphics, ollama]
+
+- name: Regenerate initramfs
+  become: true
+  ansible.builtin.command:
+    cmd: mkinitcpio -P
+  when: graphics_regenerate_initramfs and graphics_driver != "none"
+  notify: Reboot required
+  tags: [graphics, initramfs]

--- a/roles/graphics/tasks/ollama.yml
+++ b/roles/graphics/tasks/ollama.yml
@@ -1,0 +1,46 @@
+---
+# Ollama Installation and Configuration Tasks
+
+- name: Install Ollama via pacman
+  become: true
+  community.general.pacman:
+    name: ollama
+    state: present
+  when: graphics_ollama_method == "pacman"
+
+- name: Install Ollama via script
+  become: true
+  ansible.builtin.shell:
+    cmd: curl -fsSL {{ graphics_ollama_script_url }} | sh
+    creates: /usr/local/bin/ollama
+  when: graphics_ollama_method == "script"
+
+- name: Enable and start Ollama service
+  become: true
+  ansible.builtin.systemd:
+    name: ollama
+    enabled: true
+    state: "{{ graphics_ollama_service_state }}"
+  when: graphics_ollama_enable_service
+
+- name: Wait for Ollama service to be ready
+  ansible.builtin.wait_for:
+    port: 11434
+    delay: 2
+    timeout: 30
+  when: graphics_ollama_enable_service and graphics_ollama_service_state == "started"
+
+- name: Pull Ollama models
+  ansible.builtin.command:
+    cmd: "ollama pull {{ item }}"
+  loop: "{{ graphics_ollama_models }}"
+  when:
+    - graphics_ollama_models | length > 0
+    - graphics_ollama_enable_service
+    - graphics_ollama_service_state == "started"
+  register: ollama_pull_result
+  changed_when: "'pulling manifest' in ollama_pull_result.stdout"
+
+- name: Display Ollama installation complete message
+  ansible.builtin.debug:
+    msg: "Ollama installed successfully. Models: {{ graphics_ollama_models | join(', ') if graphics_ollama_models | length > 0 else 'none' }}"

--- a/vars/graphics.yml
+++ b/vars/graphics.yml
@@ -1,0 +1,48 @@
+---
+# Graphics Role Configuration
+# Override these values to customize GPU driver and Ollama installation
+
+# GPU driver selection
+# Options: nvidia, amd, intel, none
+graphics_driver: "nvidia"
+
+# NVIDIA driver packages (if using nvidia)
+# graphics_nvidia_packages:
+#   - nvidia
+#   - nvidia-utils
+#   - lib32-nvidia-utils
+
+# AMD driver packages (if using amd)
+# graphics_amd_packages:
+#   - xf86-video-amdgpu
+#   - vulkan-radeon
+#   - lib32-vulkan-radeon
+
+# Intel driver packages (if using intel)
+# graphics_intel_packages:
+#   - xf86-video-intel
+#   - vulkan-intel
+#   - lib32-vulkan-intel
+
+# CUDA toolkit installation
+graphics_install_cuda: false
+# graphics_cuda_packages:
+#   - cuda
+#   - cudnn
+
+# Ollama installation
+graphics_install_ollama: true
+graphics_ollama_method: "pacman"  # Options: pacman, script
+# graphics_ollama_script_url: "https://ollama.ai/install.sh"
+
+# Ollama service management
+graphics_ollama_enable_service: true
+graphics_ollama_service_state: "started"
+
+# Ollama models to pull after installation
+graphics_ollama_models:
+  - llama2
+  - codellama
+
+# Initramfs regeneration (required after driver installation)
+graphics_regenerate_initramfs: true


### PR DESCRIPTION
## Summary
Implements issue #92 - New graphics role for GPU driver and Ollama AI model management.

## Features
- GPU driver installation (NVIDIA/AMD/Intel)
- CUDA toolkit installation (optional, NVIDIA only)
- Ollama AI model server installation
- Ollama service management
- AI model pulling (llama2, codellama, etc.)
- Automatic initramfs regeneration
- Comprehensive documentation and examples

## Changes
- Created `roles/graphics/` with complete role structure
- Added `vars/graphics.yml` configuration
- Integrated into `playbooks/workstation.yml`
- Updated CLAUDE.md and FILESTRUCTURE.md documentation

## Testing
Recommended testing workflow:
```bash
./run.sh --tags graphics --check  # Dry-run
./run.sh --tags graphics         # Apply changes
```

Resolves #92

---

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/SkogAI/skogansible/actions/runs/20527939064) | [View branch](https://github.com/SkogAI/skogansible/tree/claude/issue-92-20251226-1913