### PR TITLE
Add graphics role for GPU drivers and Ollama management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ ansible-playbook playbook.yml --tags ssh --ask-vault-pass
 - ✅ **git** - Comprehensive Git configuration and repository management
 - ✅ **chezmoi** - Dotfiles management via machine-specific configuration templating
 - ✅ **cloudflared** - Cloudflare Tunnel with secure vault token storage
+- ✅ **graphics** - GPU drivers (NVIDIA/AMD/Intel) and Ollama AI server management
 
 **Features:**
 
@@ -173,6 +174,11 @@ ansible-playbook playbook.yml --tags ssh --ask-vault-pass
 - ✅ Cloudflare Tunnel token deployment from encrypted vault
 - ✅ Systemd service configuration with token-file (no plaintext secrets)
 - ✅ Cloudflared service enablement and management
+- ✅ GPU driver installation (NVIDIA, AMD, Intel)
+- ✅ CUDA toolkit installation (optional)
+- ✅ Ollama AI server installation and management
+- ✅ Ollama model pulling and configuration
+- ✅ Initramfs regeneration after driver changes
 - ⏸️ Additional system configuration (see `docs/system-inventory-by-primitives.md`)
 
 ## Packages Role Configuration
@@ -500,6 +506,110 @@ The Cloudflared role manages Cloudflare Tunnel with secure token storage using a
 
 **See also:** `docs/CLOUDFLARED_SETUP.md` for comprehensive setup guide.
 
+## Graphics Role Configuration
+
+The Graphics role manages GPU drivers and Ollama AI server for Arch Linux systems. All features are **disabled by default** for safety.
+
+**Quick Start (Default behavior):**
+
+- GPU drivers: disabled (set `graphics_install_drivers: true` to enable)
+- Ollama: enabled by default (`graphics_install_ollama: true`)
+- Method: pacman installation (recommended)
+
+**To configure GPU drivers:**
+
+1. Identify your GPU type:
+   ```bash
+   lspci | grep -i vga
+   ```
+
+2. Edit `vars/graphics.yml` and set your GPU type:
+   ```yaml
+   graphics_driver: nvidia  # or amd, intel, none
+   graphics_install_drivers: true
+   graphics_regenerate_initramfs: true
+   ```
+
+3. Run: `./run.sh --tags graphics`
+
+4. Reboot to load new drivers
+
+**Available Graphics Features (configure in vars/graphics.yml):**
+
+- `graphics_driver: "none"` - GPU type (nvidia, amd, intel, none)
+- `graphics_install_drivers: false` - Install GPU drivers
+- `graphics_nvidia_install_cuda: false` - Install CUDA toolkit (NVIDIA only)
+- `graphics_install_ollama: true` - Install Ollama AI server
+- `graphics_ollama_method: "pacman"` - Installation method (pacman or script)
+- `graphics_ollama_enable_service: true` - Enable Ollama systemd service
+- `graphics_ollama_pull_models: false` - Auto-pull AI models
+- `graphics_ollama_models: []` - List of models to pull
+- `graphics_regenerate_initramfs: false` - Regenerate initramfs after driver changes
+
+**GPU Driver Packages:**
+
+- **NVIDIA**: nvidia, nvidia-utils, lib32-nvidia-utils, cuda (optional)
+- **AMD**: xf86-video-amdgpu, vulkan-radeon, lib32-vulkan-radeon
+- **Intel**: xf86-video-intel, vulkan-intel, lib32-vulkan-intel
+
+**Ollama Configuration:**
+
+- Service runs on port 11434
+- Models stored in `/usr/share/ollama`
+- Systemd service: `ollama.service`
+- Common models: llama2, codellama, mistral, phi
+
+**Granular tag support:**
+
+```bash
+./run.sh --tags graphics       # All graphics tasks
+./run.sh --tags nvidia         # Only NVIDIA drivers
+./run.sh --tags amd            # Only AMD drivers
+./run.sh --tags intel          # Only Intel drivers
+./run.sh --tags cuda           # Only CUDA toolkit
+./run.sh --tags ollama         # Only Ollama
+./run.sh --tags models         # Only model pulling
+```
+
+**Example configurations:**
+
+NVIDIA with CUDA and Ollama:
+```yaml
+graphics_driver: nvidia
+graphics_install_drivers: true
+graphics_nvidia_install_cuda: true
+graphics_regenerate_initramfs: true
+graphics_install_ollama: true
+graphics_ollama_pull_models: true
+graphics_ollama_models:
+  - llama2
+  - codellama
+```
+
+AMD with Ollama:
+```yaml
+graphics_driver: amd
+graphics_install_drivers: true
+graphics_regenerate_initramfs: true
+graphics_install_ollama: true
+```
+
+Ollama only (no GPU driver changes):
+```yaml
+graphics_install_drivers: false
+graphics_install_ollama: true
+graphics_ollama_method: pacman
+```
+
+**Important notes:**
+
+- After driver installation, reboot is required
+- CUDA toolkit is ~3GB download
+- Model pulling can be bandwidth-intensive (4GB+ per model)
+- Initramfs regeneration runs automatically when drivers change
+
+**See:** `roles/graphics/README.md` for complete documentation and troubleshooting.
+
 ## Reference
 
 ### Essential Reading
@@ -515,6 +625,7 @@ The Cloudflared role manages Cloudflare Tunnel with secure token storage using a
 - @roles/ssh/README.md - SSH role documentation
 - @roles/git/README.md - Git role documentation
 - @roles/cloudflared/README.md - Cloudflared role documentation
+- @roles/graphics/README.md - Graphics role documentation
 
 ### System Expansion
 

--- a/FILESTRUCTURE.md
+++ b/FILESTRUCTURE.md
@@ -87,15 +87,27 @@ SkogAI/skogansible/
 │   │   ├── handlers/main.yml            # Handlers for chezmoi role
 │   │   └── meta/main.yml                # Role metadata
 │   │
-│   └── cloudflared/                     # Cloudflare Tunnel management role
+│   ├── cloudflared/                     # Cloudflare Tunnel management role
+│   │   ├── tasks/
+│   │   │   └── main.yml                 # Cloudflared tasks (token deployment, service management)
+│   │   ├── templates/
+│   │   │   └── cloudflared.service.j2   # Systemd service template (uses --token-file)
+│   │   ├── defaults/main.yml            # Default variables for cloudflared role
+│   │   ├── handlers/main.yml            # Handlers for cloudflared role (daemon-reload, restart)
+│   │   ├── meta/main.yml                # Role metadata
+│   │   └── README.md                    # Complete Cloudflared role documentation
+│   │
+│   └── graphics/                        # Graphics/GPU and Ollama management role
 │       ├── tasks/
-│       │   └── main.yml                 # Cloudflared tasks (token deployment, service management)
-│       ├── templates/
-│       │   └── cloudflared.service.j2   # Systemd service template (uses --token-file)
-│       ├── defaults/main.yml            # Default variables for cloudflared role
-│       ├── handlers/main.yml            # Handlers for cloudflared role (daemon-reload, restart)
+│       │   ├── main.yml                 # Main task orchestrator
+│       │   ├── nvidia.yml               # NVIDIA driver installation
+│       │   ├── amd.yml                  # AMD driver installation
+│       │   ├── intel.yml                # Intel driver installation
+│       │   └── ollama.yml               # Ollama AI server installation and configuration
+│       ├── defaults/main.yml            # Default variables for graphics role
+│       ├── handlers/main.yml            # Initramfs regeneration handler
 │       ├── meta/main.yml                # Role metadata
-│       └── README.md                    # Complete Cloudflared role documentation
+│       └── README.md                    # Complete Graphics role documentation
 │
 ├── vars/                                # Variable files (role-specific configuration)
 │   ├── main.yml                         # Shared variables across roles
@@ -107,6 +119,7 @@ SkogAI/skogansible/
 │   ├── cloudflared.yml                  # Cloudflared configuration (deployment flags, extra args)
 │   ├── cloudflared_vault.yml            # Encrypted Cloudflare tunnel token (ansible-vault)
 │   ├── cloudflared_vault.yml.template   # Template for creating vault file
+│   ├── graphics.yml                     # Graphics/GPU configuration (driver type, Ollama settings)
 │   └── user.yml                         # User-specific variables (username, groups, shell)
 │
 ├── docs/                                # Documentation directory
@@ -205,6 +218,10 @@ Manages dotfiles by templating machine-specific .chezmoidata.yaml configuration 
 
 Manages Cloudflare Tunnel with secure token storage using ansible-vault. Deploys tunnel token from encrypted vault, configures systemd service with --token-file flag (no plaintext secrets), and manages service enablement.
 
+#### graphics/
+
+Manages GPU drivers (NVIDIA, AMD, Intel) and Ollama AI server. Installs appropriate GPU drivers based on hardware type, optional CUDA toolkit, Ollama server installation via pacman or script, automatic model pulling, and initramfs regeneration after driver changes.
+
 ### Variables
 
 All role-specific configuration stored in `vars/` directory:
@@ -217,6 +234,7 @@ All role-specific configuration stored in `vars/` directory:
 - **cloudflared.yml** - Cloudflared configuration (deployment flags, extra args)
 - **cloudflared_vault.yml** - Encrypted Cloudflare tunnel token (use ansible-vault to edit)
 - **cloudflared_vault.yml.template** - Template for creating vault file
+- **graphics.yml** - Graphics/GPU configuration (driver type, Ollama settings, model list)
 - **user.yml** - User-specific variables (username, groups, shell)
 - **main.yml** - Shared variables across all roles
 
@@ -249,9 +267,9 @@ The following directories are excluded from version control (see .gitignore):
 
 ## File Counts
 
-- **5 roles** - packages, ssh, git, chezmoi, cloudflared
-- **10 variable files** - Role-specific configuration
-- **13+ task files** - Modular task definitions
+- **6 roles** - packages, ssh, git, chezmoi, cloudflared, graphics
+- **11 variable files** - Role-specific configuration
+- **18+ task files** - Modular task definitions
 - **7+ templates** - Jinja2 templates for configs and hooks
 - **12+ documentation files** - Reference and historical docs
 - **3 collections** - Ansible Galaxy collections installed

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -13,6 +13,7 @@
     - ../vars/git.yml        # Git configuration
     - ../vars/chezmoi.yml    # Chezmoi configuration
     - ../vars/zsh.yml        # Zsh configuration
+    - ../vars/graphics.yml   # Graphics/GPU configuration
 
   roles:
     - role: packages
@@ -29,3 +30,6 @@
 
     - role: zsh
       tags: [zsh, shell]
+
+    - role: graphics
+      tags: [graphics, gpu, ollama]

--- a/playbooks/workstation.yml
+++ b/playbooks/workstation.yml
@@ -15,6 +15,7 @@
     - ../vars/cloudflared.yml
     - ../vars/cloudflared_vault.yml
     - ../vars/filesystems.yml
+    - ../vars/graphics.yml
 
   roles:
     - role: packages
@@ -34,3 +35,6 @@
 
     - role: filesystems
       tags: [filesystems, mounts]
+
+    - role: graphics
+      tags: [graphics, gpu, ollama]

--- a/roles/graphics/README.md
+++ b/roles/graphics/README.md
@@ -1,0 +1,485 @@
+# Ansible Role: Graphics
+
+GPU driver and Ollama management role for Arch Linux systems.
+
+This role provides comprehensive graphics and AI infrastructure management including:
+
+- NVIDIA GPU drivers and CUDA toolkit
+- AMD GPU drivers and Vulkan support
+- Intel GPU drivers and Vulkan support
+- Ollama AI model server installation and configuration
+- Automatic model pulling and service management
+- Initramfs regeneration for kernel module updates
+
+## Requirements
+
+- Ansible 2.10 or higher
+- `community.general` collection (for `pacman` module)
+- Target system: Arch Linux
+- User must have sudo privileges
+- Compatible GPU hardware (NVIDIA, AMD, or Intel)
+
+## Role Variables
+
+All role variables are defined in `defaults/main.yml` with sensible defaults. Override them in your playbook, inventory, or `vars/graphics.yml`.
+
+### GPU Driver Selection
+
+```yaml
+graphics_driver: "none"              # Options: nvidia, amd, intel, none
+graphics_install_drivers: false      # Set to true to install GPU drivers
+```
+
+### NVIDIA Configuration
+
+```yaml
+graphics_nvidia_packages:            # NVIDIA driver packages
+  - nvidia
+  - nvidia-utils
+  - lib32-nvidia-utils
+graphics_nvidia_install_cuda: false  # Install CUDA toolkit
+graphics_nvidia_cuda_packages:       # CUDA packages
+  - cuda
+  - cuda-tools
+```
+
+### AMD Configuration
+
+```yaml
+graphics_amd_packages:               # AMD driver packages
+  - xf86-video-amdgpu
+  - vulkan-radeon
+  - lib32-vulkan-radeon
+```
+
+### Intel Configuration
+
+```yaml
+graphics_intel_packages:             # Intel driver packages
+  - xf86-video-intel
+  - vulkan-intel
+  - lib32-vulkan-intel
+```
+
+### Ollama Configuration
+
+```yaml
+graphics_install_ollama: true        # Install Ollama
+graphics_ollama_method: "pacman"     # Installation method: pacman or script
+graphics_ollama_install_url: "https://ollama.com/install.sh"  # Script URL
+graphics_ollama_enable_service: true # Enable systemd service
+graphics_ollama_start_service: true  # Start service after installation
+```
+
+### Ollama Model Management
+
+```yaml
+graphics_ollama_pull_models: false   # Automatically pull models
+graphics_ollama_models: []           # List of models to pull
+# Example models:
+# - llama2
+# - codellama
+# - mistral
+# - phi
+```
+
+### System Configuration
+
+```yaml
+graphics_regenerate_initramfs: false # Regenerate initramfs after driver installation
+```
+
+## Dependencies
+
+None.
+
+## Example Playbooks
+
+### NVIDIA GPU Setup
+
+Install NVIDIA drivers and Ollama:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "nvidia"
+        graphics_install_drivers: true
+        graphics_regenerate_initramfs: true
+        graphics_install_ollama: true
+```
+
+### NVIDIA with CUDA and Models
+
+Install NVIDIA drivers, CUDA toolkit, Ollama, and pull AI models:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "nvidia"
+        graphics_install_drivers: true
+        graphics_nvidia_install_cuda: true
+        graphics_regenerate_initramfs: true
+        graphics_install_ollama: true
+        graphics_ollama_pull_models: true
+        graphics_ollama_models:
+          - llama2
+          - codellama
+          - mistral
+```
+
+### AMD GPU Setup
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "amd"
+        graphics_install_drivers: true
+        graphics_regenerate_initramfs: true
+        graphics_install_ollama: true
+```
+
+### Intel GPU Setup
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_driver: "intel"
+        graphics_install_drivers: true
+        graphics_regenerate_initramfs: true
+        graphics_install_ollama: true
+```
+
+### Ollama Only (No GPU Drivers)
+
+Install only Ollama without GPU driver changes:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_install_drivers: false
+        graphics_install_ollama: true
+        graphics_ollama_method: "pacman"
+```
+
+### Ollama with Script Installation
+
+Use the official Ollama installation script instead of pacman:
+
+```yaml
+- hosts: localhost
+  roles:
+    - role: graphics
+      vars:
+        graphics_install_drivers: false
+        graphics_install_ollama: true
+        graphics_ollama_method: "script"
+```
+
+## Role Tasks
+
+The role executes tasks in this order:
+
+### 1. GPU Driver Installation
+
+Installs appropriate GPU drivers based on `graphics_driver`:
+
+- **NVIDIA** (`nvidia.yml`): Installs nvidia, nvidia-utils, lib32-nvidia-utils, optionally CUDA
+- **AMD** (`amd.yml`): Installs xf86-video-amdgpu, vulkan-radeon, lib32-vulkan-radeon
+- **Intel** (`intel.yml`): Installs xf86-video-intel, vulkan-intel, lib32-vulkan-intel
+
+All driver installations trigger initramfs regeneration if `graphics_regenerate_initramfs: true`.
+
+### 2. Ollama Installation (`ollama.yml`)
+
+- Installs Ollama via pacman or official script
+- Enables and starts ollama systemd service
+- Waits for service to be ready (port 11434)
+- Pulls specified AI models
+
+## Tags
+
+The role supports granular execution via tags:
+
+- `graphics` - All graphics tasks
+- `nvidia` - NVIDIA driver tasks only
+- `amd` - AMD driver tasks only
+- `intel` - Intel driver tasks only
+- `cuda` - CUDA toolkit installation
+- `ollama` - Ollama installation and configuration
+- `service` - Ollama service management
+- `models` - AI model pulling
+
+### Tag Usage Examples
+
+```bash
+# Install only NVIDIA drivers
+ansible-playbook playbook.yml --tags nvidia
+
+# Install only Ollama
+ansible-playbook playbook.yml --tags ollama
+
+# Install Ollama and pull models
+ansible-playbook playbook.yml --tags ollama,models
+
+# Full graphics setup
+ansible-playbook playbook.yml --tags graphics
+```
+
+## Variables File Example
+
+Create `vars/graphics.yml`:
+
+```yaml
+---
+# GPU Configuration
+graphics_driver: "nvidia"
+graphics_install_drivers: true
+graphics_nvidia_install_cuda: true
+graphics_regenerate_initramfs: true
+
+# Ollama Configuration
+graphics_install_ollama: true
+graphics_ollama_method: "pacman"
+graphics_ollama_enable_service: true
+graphics_ollama_start_service: true
+
+# AI Models
+graphics_ollama_pull_models: true
+graphics_ollama_models:
+  - llama2
+  - codellama
+  - mistral
+  - phi
+```
+
+## Handlers
+
+### Regenerate initramfs
+
+Triggered when GPU drivers are installed and `graphics_regenerate_initramfs: true`:
+
+```yaml
+- name: Regenerate initramfs
+  become: true
+  ansible.builtin.command:
+    cmd: mkinitcpio -P
+```
+
+**Important**: After initramfs regeneration, a system reboot is recommended to load the new kernel modules.
+
+## Security Considerations
+
+### Ollama Service
+
+The Ollama service runs as a system service and listens on port 11434. By default, it's accessible only from localhost. To expose it to the network, additional firewall configuration may be required.
+
+### CUDA Toolkit
+
+The CUDA toolkit is large (~3GB) and includes development tools. Only install if you need CUDA development capabilities.
+
+### Model Pulling
+
+Model pulling can be bandwidth-intensive and time-consuming:
+
+- llama2: ~4GB
+- codellama: ~4GB
+- mistral: ~4GB
+- phi: ~1.6GB
+
+Set `graphics_ollama_pull_models: false` and pull models manually if preferred:
+
+```bash
+ollama pull llama2
+ollama pull codellama
+```
+
+## Troubleshooting
+
+### GPU Drivers Not Loading
+
+After driver installation, regenerate initramfs and reboot:
+
+```bash
+sudo mkinitcpio -P
+sudo reboot
+```
+
+Verify driver loading:
+
+```bash
+# NVIDIA
+nvidia-smi
+
+# AMD
+lspci -k | grep -A 3 VGA
+
+# Intel
+lspci -k | grep -A 3 VGA
+```
+
+### Ollama Service Not Starting
+
+Check service status:
+
+```bash
+sudo systemctl status ollama
+journalctl -u ollama -f
+```
+
+Verify Ollama binary:
+
+```bash
+which ollama
+ollama --version
+```
+
+Test Ollama manually:
+
+```bash
+ollama serve  # Run in foreground to see errors
+```
+
+### Model Pulling Fails
+
+Check network connectivity:
+
+```bash
+curl -I https://ollama.com
+```
+
+Check available disk space:
+
+```bash
+df -h /usr/share/ollama  # Default model storage
+```
+
+Pull models manually with verbose output:
+
+```bash
+ollama pull llama2 --verbose
+```
+
+### CUDA Not Found
+
+Verify CUDA installation:
+
+```bash
+nvcc --version
+ls -la /opt/cuda
+```
+
+Add CUDA to PATH in your shell profile:
+
+```bash
+export PATH=/opt/cuda/bin:$PATH
+export LD_LIBRARY_PATH=/opt/cuda/lib64:$LD_LIBRARY_PATH
+```
+
+### Initramfs Regeneration Fails
+
+Check for errors:
+
+```bash
+sudo mkinitcpio -P
+```
+
+Common issues:
+
+- Missing linux kernel package
+- Corrupted kernel modules
+- Insufficient disk space in /boot
+
+## Testing
+
+Test the role in check mode (dry-run):
+
+```bash
+ansible-playbook playbook.yml --tags graphics --check
+```
+
+Test specific components:
+
+```bash
+# Test NVIDIA driver installation
+ansible-playbook playbook.yml --tags nvidia --check
+
+# Test Ollama installation
+ansible-playbook playbook.yml --tags ollama --check
+
+# Test model pulling
+ansible-playbook playbook.yml --tags models --check
+```
+
+## Role Structure
+
+```
+roles/graphics/
+├── tasks/
+│   ├── main.yml           # Main task orchestrator
+│   ├── nvidia.yml         # NVIDIA driver installation
+│   ├── amd.yml            # AMD driver installation
+│   ├── intel.yml          # Intel driver installation
+│   └── ollama.yml         # Ollama installation and configuration
+├── defaults/main.yml      # Default variables
+├── handlers/main.yml      # Initramfs regeneration handler
+├── meta/main.yml          # Role metadata
+└── README.md              # This file
+```
+
+## Integration with Playbook
+
+Add the graphics role to your main playbook:
+
+```yaml
+---
+- name: System configuration
+  hosts: localhost
+  connection: local
+
+  vars_files:
+    - vars/main.yml
+    - vars/packages.yml
+    - vars/graphics.yml  # Add this
+
+  roles:
+    - packages
+    - graphics  # Add this
+    - ssh
+    - git
+    - chezmoi
+
+  tags:
+    - all
+```
+
+Run with:
+
+```bash
+./run.sh --tags graphics
+```
+
+## License
+
+MIT
+
+## Author
+
+SkogAI (skogansible repository)
+
+## Further Reading
+
+- [NVIDIA Arch Wiki](https://wiki.archlinux.org/title/NVIDIA)
+- [AMDGPU Arch Wiki](https://wiki.archlinux.org/title/AMDGPU)
+- [Intel Graphics Arch Wiki](https://wiki.archlinux.org/title/Intel_graphics)
+- [Ollama Documentation](https://ollama.com/docs)
+- [CUDA Toolkit Documentation](https://docs.nvidia.com/cuda/)

--- a/roles/graphics/defaults/main.yml
+++ b/roles/graphics/defaults/main.yml
@@ -1,0 +1,46 @@
+---
+# Graphics role default variables
+
+# GPU Driver Selection
+graphics_driver: "none"  # Options: nvidia, amd, intel, none
+graphics_install_drivers: false  # Set to true to install GPU drivers
+
+# NVIDIA Configuration
+graphics_nvidia_packages:
+  - nvidia
+  - nvidia-utils
+  - lib32-nvidia-utils
+graphics_nvidia_install_cuda: false
+graphics_nvidia_cuda_packages:
+  - cuda
+  - cuda-tools
+
+# AMD Configuration
+graphics_amd_packages:
+  - xf86-video-amdgpu
+  - vulkan-radeon
+  - lib32-vulkan-radeon
+
+# Intel Configuration
+graphics_intel_packages:
+  - xf86-video-intel
+  - vulkan-intel
+  - lib32-vulkan-intel
+
+# Ollama Configuration
+graphics_install_ollama: true
+graphics_ollama_method: "pacman"  # Options: pacman, script
+graphics_ollama_install_url: "https://ollama.com/install.sh"
+graphics_ollama_enable_service: true
+graphics_ollama_start_service: true
+
+# Ollama Model Management
+graphics_ollama_pull_models: false
+graphics_ollama_models: []
+# Example models:
+# - llama2
+# - codellama
+# - mistral
+
+# Service Management
+graphics_regenerate_initramfs: false  # Set to true if kernel modules changed

--- a/roles/graphics/handlers/main.yml
+++ b/roles/graphics/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# Graphics role handlers
+
+- name: Regenerate initramfs
+  become: true
+  ansible.builtin.command:
+    cmd: mkinitcpio -P
+  when: graphics_regenerate_initramfs
+  listen: "Regenerate initramfs"

--- a/roles/graphics/meta/main.yml
+++ b/roles/graphics/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  author: SkogAI
+  description: GPU driver and Ollama management for Arch Linux
+  company: SkogAI
+  license: MIT
+  min_ansible_version: "2.10"
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+  galaxy_tags:
+    - graphics
+    - gpu
+    - nvidia
+    - amd
+    - intel
+    - ollama
+    - ai
+    - llm
+
+dependencies: []

--- a/roles/graphics/tasks/amd.yml
+++ b/roles/graphics/tasks/amd.yml
@@ -1,0 +1,14 @@
+---
+# AMD GPU driver installation tasks
+
+- name: Install AMD drivers
+  become: true
+  community.general.pacman:
+    name: "{{ graphics_amd_packages }}"
+    state: present
+  when: graphics_install_drivers and graphics_driver == "amd"
+  notify:
+    - Regenerate initramfs
+  tags:
+    - graphics
+    - amd

--- a/roles/graphics/tasks/intel.yml
+++ b/roles/graphics/tasks/intel.yml
@@ -1,0 +1,14 @@
+---
+# Intel GPU driver installation tasks
+
+- name: Install Intel drivers
+  become: true
+  community.general.pacman:
+    name: "{{ graphics_intel_packages }}"
+    state: present
+  when: graphics_install_drivers and graphics_driver == "intel"
+  notify:
+    - Regenerate initramfs
+  tags:
+    - graphics
+    - intel

--- a/roles/graphics/tasks/main.yml
+++ b/roles/graphics/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# Graphics role main tasks - GPU drivers and Ollama management
+
+- name: Include NVIDIA driver tasks
+  ansible.builtin.include_tasks: nvidia.yml
+  when: graphics_install_drivers and graphics_driver == "nvidia"
+  tags:
+    - graphics
+    - nvidia
+
+- name: Include AMD driver tasks
+  ansible.builtin.include_tasks: amd.yml
+  when: graphics_install_drivers and graphics_driver == "amd"
+  tags:
+    - graphics
+    - amd
+
+- name: Include Intel driver tasks
+  ansible.builtin.include_tasks: intel.yml
+  when: graphics_install_drivers and graphics_driver == "intel"
+  tags:
+    - graphics
+    - intel
+
+- name: Include Ollama tasks
+  ansible.builtin.include_tasks: ollama.yml
+  when: graphics_install_ollama
+  tags:
+    - graphics
+    - ollama

--- a/roles/graphics/tasks/nvidia.yml
+++ b/roles/graphics/tasks/nvidia.yml
@@ -1,0 +1,28 @@
+---
+# NVIDIA GPU driver installation tasks
+
+- name: Install NVIDIA drivers
+  become: true
+  community.general.pacman:
+    name: "{{ graphics_nvidia_packages }}"
+    state: present
+  when: graphics_install_drivers and graphics_driver == "nvidia"
+  notify:
+    - Regenerate initramfs
+  tags:
+    - graphics
+    - nvidia
+
+- name: Install NVIDIA CUDA toolkit
+  become: true
+  community.general.pacman:
+    name: "{{ graphics_nvidia_cuda_packages }}"
+    state: present
+  when:
+    - graphics_install_drivers
+    - graphics_driver == "nvidia"
+    - graphics_nvidia_install_cuda
+  tags:
+    - graphics
+    - nvidia
+    - cuda

--- a/roles/graphics/tasks/ollama.yml
+++ b/roles/graphics/tasks/ollama.yml
@@ -1,0 +1,104 @@
+---
+# Ollama installation and management tasks
+
+- name: Install Ollama via pacman
+  become: true
+  community.general.pacman:
+    name: ollama
+    state: present
+  when:
+    - graphics_install_ollama
+    - graphics_ollama_method == "pacman"
+  tags:
+    - graphics
+    - ollama
+
+- name: Download Ollama install script
+  ansible.builtin.get_url:
+    url: "{{ graphics_ollama_install_url }}"
+    dest: /tmp/ollama_install.sh
+    mode: '0755'
+  when:
+    - graphics_install_ollama
+    - graphics_ollama_method == "script"
+  tags:
+    - graphics
+    - ollama
+
+- name: Install Ollama via script
+  become: true
+  ansible.builtin.command:
+    cmd: /tmp/ollama_install.sh
+    creates: /usr/local/bin/ollama
+  when:
+    - graphics_install_ollama
+    - graphics_ollama_method == "script"
+  tags:
+    - graphics
+    - ollama
+
+- name: Remove Ollama install script
+  ansible.builtin.file:
+    path: /tmp/ollama_install.sh
+    state: absent
+  when:
+    - graphics_install_ollama
+    - graphics_ollama_method == "script"
+  tags:
+    - graphics
+    - ollama
+
+- name: Enable Ollama service
+  become: true
+  ansible.builtin.systemd:
+    name: ollama
+    enabled: true
+  when:
+    - graphics_install_ollama
+    - graphics_ollama_enable_service
+  tags:
+    - graphics
+    - ollama
+    - service
+
+- name: Start Ollama service
+  become: true
+  ansible.builtin.systemd:
+    name: ollama
+    state: started
+  when:
+    - graphics_install_ollama
+    - graphics_ollama_start_service
+  tags:
+    - graphics
+    - ollama
+    - service
+
+- name: Wait for Ollama service to be ready
+  ansible.builtin.wait_for:
+    port: 11434
+    delay: 2
+    timeout: 30
+  when:
+    - graphics_install_ollama
+    - graphics_ollama_pull_models
+    - graphics_ollama_models | length > 0
+  tags:
+    - graphics
+    - ollama
+    - models
+
+- name: Pull Ollama models
+  ansible.builtin.command:
+    cmd: "ollama pull {{ item }}"
+  loop: "{{ graphics_ollama_models }}"
+  when:
+    - graphics_install_ollama
+    - graphics_ollama_pull_models
+    - graphics_ollama_models | length > 0
+  register: ollama_pull_result
+  changed_when: "'pulling' in ollama_pull_result.stdout or 'success' in ollama_pull_result.stdout"
+  tags:
+    - graphics
+    - ollama
+    - models

--- a/vars/graphics.yml
+++ b/vars/graphics.yml
@@ -1,0 +1,30 @@
+---
+# Graphics configuration variables
+# Override these values based on your system configuration
+
+# GPU Driver Configuration
+# Set to nvidia, amd, intel, or none based on your hardware
+graphics_driver: "nvidia"
+graphics_install_drivers: true
+
+# NVIDIA-specific Configuration
+graphics_nvidia_install_cuda: false
+
+# Ollama Configuration
+graphics_install_ollama: true
+graphics_ollama_method: "pacman"  # pacman or script
+graphics_ollama_enable_service: true
+graphics_ollama_start_service: true
+
+# Ollama Models
+# Set to true to automatically pull models after installation
+graphics_ollama_pull_models: false
+graphics_ollama_models:
+  - llama2
+  # - codellama
+  # - mistral
+  # - phi
+
+# Initramfs Regeneration
+# Set to true if installing GPU drivers that require initramfs regeneration
+graphics_regenerate_initramfs: true


### PR DESCRIPTION
Implements issue #92

## Summary
Creates a new `roles/graphics/` role for managing GPU drivers and Ollama AI server.

## Changes
- ✅ GPU driver installation (NVIDIA, AMD, Intel)
- ✅ Optional CUDA toolkit support
- ✅ Ollama AI server installation and management
- ✅ Automatic model pulling
- ✅ Initramfs regeneration handler
- ✅ Comprehensive documentation
- ✅ Granular tag support

## Testing
Run with: `./run.sh --tags graphics`

Generated with [Claude Code](https://claude.ai/code)) | [Branch](https://github.com/SkogAI/skogansible/tree/claude/issue-92-20251226-1916) | [View job run](https://github.com/SkogAI/skogansible/actions/runs/20527990751